### PR TITLE
Target v0.5+ and fix v0.6 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: julia
 os:
   - osx
 julia:
-  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - julia: nightly

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AppleAccelerate.jl
 
-[![Build Status](https://travis-ci.org/JuliaLang/AppleAccelerate.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/AppleAccelerate.jl)
+[![Build Status](https://travis-ci.org/JuliaMath/AppleAccelerate.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/AppleAccelerate.jl)
 
 This provides a Julia interface to some of
 [OS X's Accelerate framework](https://developer.apple.com/library/mac/documentation/Accelerate/Reference/AccelerateFWRef/). At
@@ -26,10 +26,10 @@ Note there are some slight differences from behaviour in Base:
 
 Some additional functions that are also available:
 * `rec(x)`: reciprocal (`1.0 ./ x`)
-* `rsqrt(x)`: reciprocal square-root (`1.0 ./ sqrt(x)`)
+* `rsqrt(x)`: reciprocal square-root (`1.0 ./ sqrt.(x)`)
 * `pow(x,y)`: power (`x .^ y` in Base)
 * `fdiv(x,y)`: divide (`x ./ y` in Base)
-* `sincos(x)`: returns `(sin(x), cos(x))`
+* `sincos(x)`: returns `(sin.(x), cos.(x))`
 
 ## Example
 
@@ -38,7 +38,7 @@ be accessed via the namespace:
 ```julia
 using AppleAccelerate
 X = randn(1_000_000)
-@time Y = exp(X) # standard libm function
+@time Y = exp.(X) # standard libm function
 @time Y = AppleAccelerate.exp(X) # Accelerate array-oriented function
 ```
 
@@ -52,7 +52,7 @@ AppleAccelerate.@replaceBase(.^, ./) # use parenthesised form for infix ops
 Output arrays can be specified as first arguments of the functions suffixed
 with `!`:
 ```julia
-out = Array(Float64,1_000_000)
+out = Array{Float64}(1_000_000)
 @time AppleAccelerate.exp!(out, X)
 ```
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -7,10 +7,10 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
               :exp,:exp2,:expm1,:log,:log1p,:log2,:log10,
               :sin,:sinpi,:cos,:cospi,:tan,:tanpi,:asin,:acos,:atan,
               :sinh,:cosh,:tanh,:asinh,:acosh,:atanh)
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T})
-                out = Array($T,size(X))
+                out = Array{$T}(size(X))
                 ($f!)(out, X)
             end
             function ($f!)(out::Array{$T}, X::Array{$T})
@@ -24,10 +24,10 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # renamed 1 arg functions
     for (f,fa) in ((:trunc,:int),(:round,:nint),(:exponent,:logb),
                    (:abs,:fabs))
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T})
-                out = Array($T,size(X))
+                out = Array{$T}(size(X))
                 ($f!)(out, X)
             end
             function ($f!)(out::Array{$T}, X::Array{$T})
@@ -40,11 +40,11 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
 
     # 2 arg functions
     for f in (:copysign,:atan2)
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
-                out = Array($T,size(X))
+                out = Array{$T}(size(X))
                 ($f!)(out, X, Y)
             end
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
@@ -57,11 +57,11 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
 
     # for some bizarre reason, vvpow/vvpowf reverse the order of arguments.
     for f in (:pow,)
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
-                out = Array($T,size(X))
+                out = Array{$T}(size(X))
                 ($f!)(out, X, Y)
             end
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
@@ -75,11 +75,11 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
 
     # renamed 2 arg functions
     for (f,fa) in ((:rem,:fmod),(:fdiv,:div))
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
-                out = Array($T,size(X))
+                out = Array{$T}(size(X))
                 ($f!)(out, X, Y)
             end
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
@@ -92,11 +92,11 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
 
     # two-arg return
     for f in (:sincos,)
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T})
-                out1 = Array($T,size(X))
-                out2 = Array($T,size(X))
+                out1 = Array{$T}(size(X))
+                out2 = Array{$T}(size(X))
                 ($f!)(out1, out2, X)
             end
             function ($f!)(out1::Array{$T}, out2::Array{$T}, X::Array{$T})
@@ -109,10 +109,10 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
 
     # complex return
     for (f,fa) in ((:cis,:cosisin),)
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
         @eval begin
             function ($f)(X::Array{$T})
-                out = Array(Complex{$T},size(X))
+                out = Array{Complex{$T}}(size(X))
                 ($f!)(out, X)
             end
             function ($f!)(out::Array{Complex{$T}}, X::Array{$T})
@@ -159,7 +159,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
 
     for (f, name) in ((:vadd, "addition"),  (:vsub, "subtraction"),
                       (:vdiv, "division"), (:vmul, "multiplication"))
-        f! = symbol("$(f)!")
+        f! = Symbol("$(f)!")
 
         @eval begin
             @doc """

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -57,7 +57,7 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
     """
     @eval begin
         function conv(X::Vector{$T}, K::Vector{$T})
-            result = Array($T, length(X) + length(K) - 1)
+            result = Array{$T}(length(X) + length(K) - 1)
             conv!(result, X, K)
         end
     end
@@ -104,7 +104,7 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
     """
     @eval begin
         function xcorr(X::Vector{$T}, Y::Vector{$T})
-            result = Array($T, length(X) + length(Y) - 1)
+            result = Array{$T}(length(X) + length(Y) - 1)
             xcorr!(result, X, Y)
         end
     end
@@ -225,7 +225,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     """
     @eval begin
         function blackman(length::Int, rtype::DataType=Float64)
-            result::Vector{rtype} = Array(rtype, length)
+            result::Vector{rtype} = Array{rtype}(length)
             blackman!(result, length, 0)
         end
     end
@@ -255,7 +255,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     """
     @eval begin
         function hamming(length::Int, rtype::DataType=Float64)
-            result::Vector{rtype} = Array(rtype, length)
+            result::Vector{rtype} = Array{rtype}(length)
             hamming!(result, length, 0)
         end
     end
@@ -291,7 +291,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     """
     @eval begin
         function hanning(length::Int, rtype::DataType=Float64)
-            result::Vector{rtype} = Array(rtype, length)
+            result::Vector{rtype} = Array{rtype}(length)
             hanning!(result, length, 0)
         end
     end

--- a/src/Util.jl
+++ b/src/Util.jl
@@ -28,10 +28,16 @@ macro replaceBase(fs...)
                 (Base.$f)(X::Array{Float64}) = ($fa)(X)
                 (Base.$f)(X::Array{Float32}) = ($fa)(X)
             end
-        elseif fa in (:copysign,:atan2,:pow,:rem,:fdiv, :vadd, :vsub, :vmul)
+        elseif fa in (:copysign,:atan2,:rem)
             e = quote
-                (Base.$f)(X::Array{Float64},Y::Array{Float64}) = ($fa)(X,Y)
-                (Base.$f)(X::Array{Float32},Y::Array{Float32}) = ($fa)(X,Y)
+                (Base.$f)(X::Array{Float32}, Y::Array{Float32}) = ($fa)(X,Y)
+                (Base.$f)(X::Array{Float64}, Y::Array{Float64}) = ($fa)(X,Y)
+            end
+        elseif fa in (:fdiv,:pow,:vadd,:vsub,:vmul)
+            fb = Symbol(replace(string(f), r"^\.(.*)", s"\1"))
+            e = quote
+                Base.broadcast(::typeof(Base.$fb), X::Array{Float64}, Y::Array{Float64}) = ($fa)(X,Y)
+                Base.broadcast(::typeof(Base.$fb), X::Array{Float32}, Y::Array{Float32}) = ($fa)(X,Y)
             end
         else
             error("Function $f not defined by AppleAccelerate.jl")

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
-BaseTestNext
 DSP

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,7 @@
 using AppleAccelerate
 using DSP
 
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 srand(7)
 N = 1_000
@@ -29,7 +24,7 @@ for T in (Float32, Float64)
         @testset "Testing $f::$T" for f in [:floor,:ceil,:trunc,:round]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
     end
 end
@@ -37,11 +32,11 @@ end
 
 for T in (Float32, Float64)
     @testset "Logarithmic::$T" begin
-        X::Array{T} = exp(10*randn(N))
+        X::Array{T} = exp.(10*randn(N))
         @testset "Testing $f::$T" for f in [:log,:log2,:log10, :log1p]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
     end
 end
@@ -53,7 +48,7 @@ for T in (Float32, Float64)
             X::Array{T} = 10*randn(N)
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
     end
 end
@@ -65,21 +60,21 @@ for T in (Float32, Float64)
         @testset "Testing $f::$T" for f in [:sin,:sinpi,:cos,:cospi,:tan,:atan] # tanpi not defined in Base
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
 
         Y::Array{T} = 10*randn(N)
         @testset "Testing $f::$T" for f in [:atan2]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X,Y) ≈ fb(X,Y)
+            @test fa(X,Y) ≈ fb.(X,Y)
         end
 
         Z::Array{T} = 2*rand(N)-1
         @testset "Testing $f::$T" for f in [:asin,:acos]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(Z) ≈ fb(Z)
+            @test fa(Z) ≈ fb.(Z)
         end
     end
 end
@@ -91,21 +86,21 @@ for T in (Float32, Float64)
         @testset "Testing $f::$T" for f in [:sinh,:cosh,:tanh,:asinh]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
 
-        Y = exp(10*randn(N))+1
+        Y = exp.(10*randn(N))+1
         @testset "Testing $f::$T" for f in [:acosh]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(Y) ≈ fb(Y)
+            @test fa(Y) ≈ fb.(Y)
         end
 
         Z = 2*rand(N)-1
         @testset "Testing $f::$T" for f in [:atanh]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(Z) ≈ fb(Z)
+            @test fa(Z) ≈ fb.(Z)
         end
     end
 end
@@ -157,7 +152,7 @@ for T in (Float32, Float64)
         N = 64
         @testset "Testing blackman::$T" begin
             Wa = AppleAccelerate.blackman(N, T)
-            Wb = Array(T, N)
+            Wb = Array{T}(N)
             for n in 1:N
                 Wb[n] = 0.42-(0.5cos(2pi*(n-1)/N)) + (0.08cos(4pi*(n-1)/N))
             end
@@ -166,7 +161,7 @@ for T in (Float32, Float64)
 
         @testset "Testing hamming::$T" begin
             Wa = AppleAccelerate.hamming(N, T)
-            Wb = Array(T, N)
+            Wb = Array{T}(N)
             for n in 1:N
                 Wb[n] = 0.54-0.46cos(2pi*(n-1)/N)
             end
@@ -175,7 +170,7 @@ for T in (Float32, Float64)
 
         @testset "Testing hanning::$T" begin
             Wa = AppleAccelerate.hanning(N, T)
-            Wb = Array(T, N)
+            Wb = Array{T}(N)
             for n in 1:N
                 Wb[n] = 0.5(1.0-cos(2pi*(n-1)/N))
             end
@@ -205,7 +200,7 @@ for T in (Float32, Float64)
         end
 
         @testset "Testing meanmag::$T" begin
-            @test AppleAccelerate.meanmag(X) ≈ mean(abs(X))
+            @test AppleAccelerate.meanmag(X) ≈ mean(abs.(X))
         end
 
     end
@@ -213,25 +208,25 @@ end
 
 for T in (Float32, Float64)
     @testset "Misc::$T" begin
-        X::Array{T} = exp(10*randn(N))
+        X::Array{T} = exp.(10*randn(N))
         @testset "Testing $f::$T" for f in [:sqrt]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
 
         Y::Array{T} = 10*randn(N)
         @testset "Testing $f::$T" for f in [:exponent, :abs]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(Y) ≈ fb(Y)
+            @test fa(Y) ≈ fb.(Y)
         end
 
         Z::Array{T} = 10*randn(N)
         @testset "Testing $f::$T" for f in [:copysign]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
-            @test fa(X,Y) ≈ fb(X,Y)
+            @test fa(X,Y) ≈ fb.(X,Y)
         end
 
         @test AppleAccelerate.rem(X,Y) == [rem(X[i], Y[i]) for i=1:length(X)]
@@ -243,16 +238,16 @@ end
 for T in (Float32, Float64)
     @testset "Extra::$T" begin
         X::Array{T} = randn(N)
-        Y::Array{T} = abs(randn(N))
+        Y::Array{T} = abs.(randn(N))
 
-        @test AppleAccelerate.rec(X) ≈ 1./X
-        @test AppleAccelerate.rsqrt(Y) ≈ 1./sqrt(Y)
+        @test AppleAccelerate.rec(X) ≈ 1 ./ X
+        @test AppleAccelerate.rsqrt(Y) ≈ 1 ./ sqrt.(Y)
         @test AppleAccelerate.pow(Y,X) ≈ Y.^X
         @test AppleAccelerate.fdiv(X,Y) ≈ X./Y
 
-        @test AppleAccelerate.sincos(X)[1] ≈ sin(X)
-        @test AppleAccelerate.sincos(X)[2] ≈ cos(X)
-        @test AppleAccelerate.cis(X) ≈ cis(X)
+        @test AppleAccelerate.sincos(X)[1] ≈ sin.(X)
+        @test AppleAccelerate.sincos(X)[2] ≈ cos.(X)
+        @test AppleAccelerate.cis(X) ≈ cis.(X)
 
     end
 end
@@ -262,7 +257,7 @@ AppleAccelerate.@replaceBase(sin, atan2, ./)
 
 @testset "Replace Base::$T" for T in (Float32, Float64)
     X::Array{T} = randn(N)
-    Y::Array{T} = abs(randn(N))
+    Y::Array{T} = abs.(randn(N))
 
     @test Base.sin(X) == AppleAccelerate.sin(X)
     @test Base.atan2(X, Y) == AppleAccelerate.atan2(X, Y)


### PR DESCRIPTION
This PR allows AppleAccelerate to work on v0.5 upwards and removes support for v0.4.  It removes deprecation warnings on v0.6 for all but the inner constructors, which can only be eliminated by upping the `REQUIRE`d version to v0.6.

I hadn't spotted #28 before creating this branch locally for my own purposes.  If people are happy to drop v0.5, then this can either be dropped in favour of #28, or this updated.  Either way, I think #29 (which this closes) shows some people would like to use this package.

All tests pass locally on v0.5 and v0.6.  Let's see what CI does...