### PR TITLE
ccall using tuple rather than handle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "AppleAccelerate"
 uuid = "13e28ba4-7ad8-5781-acae-3021b1ed3924"
 version = "0.3.2"
 
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
 [compat]
 julia = "1.6"
 
@@ -13,4 +16,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = [ "DSP", "Statistics", "LinearAlgebra", "Test", "Random"]
+test = ["DSP", "Statistics", "LinearAlgebra", "Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,9 +2,6 @@ name = "AppleAccelerate"
 uuid = "13e28ba4-7ad8-5781-acae-3021b1ed3924"
 version = "0.3.2"
 
-[deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
 [compat]
 julia = "1.6"
 
@@ -16,4 +13,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DSP", "Statistics", "LinearAlgebra", "Test", "Random"]
+test = [ "DSP", "Statistics", "LinearAlgebra", "Test", "Random"]

--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -4,17 +4,19 @@ using Libdl
 
 if Sys.isapple()
 
-try
-    global const libacc = dlopen("/System/Library/Frameworks/Accelerate.framework/Accelerate")
-catch
-    error("Accelerate framework not found.")
-end
+    try
+        global const libacc = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
+        let accel_lib = dlopen(libacc)
+            dlclose(accel_lib)
+        end
+    catch
+        error("Accelerate framework not found.")
+    end
 
-get_fptr(s) = dlsym(libacc, s)
 
-include("Array.jl")
-include("DSP.jl")
-include("Util.jl")
+    include("Array.jl")
+    include("DSP.jl")
+    include("Util.jl")
 
 end
 

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -27,9 +27,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
 
             # In-place mutating variant
             function ($f!)(out::Array{$T}, X::Array{$T})
-                fptr = get_fptr($(string("vv", fa, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{$T}, Ptr{$T}, Ref{Cint}), out, X, length(X))
+                ccall(($(string("vv",fa,suff)),libacc),Cvoid,
+                      (Ptr{$T},Ptr{$T},Ref{Cint}),out,X,length(X))
                 out
             end
         end
@@ -53,9 +52,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
                 ($f!)(out, X, Y)
             end
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
-                fptr = get_fptr($(string("vv", fa, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{$T}, Ptr{$T}, Ptr{$T}, Ref{Cint}), out, X, Y, length(X))
+                ccall(($(string("vv",fa,suff)),libacc),Cvoid,
+                      (Ptr{$T},Ptr{$T},Ptr{$T},Ref{Cint}),out,X,Y,length(X))
                 out
             end
         end
@@ -71,9 +69,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
                 ($f!)(out, X, Y)
             end
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
-                fptr = get_fptr($(string("vv", fa, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{$T}, Ptr{$T}, Ptr{$T}, Ref{Cint}), out, Y, X, length(X))
+                ccall(($(string("vv",fa,suff)),libacc),Cvoid,
+                      (Ptr{$T},Ptr{$T},Ptr{$T},Ref{Cint}),out,Y,X,length(X))
                 out
             end
         end
@@ -89,9 +86,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
                 ($f!)(out1, out2, X)
             end
             function ($f!)(out1::Array{$T}, out2::Array{$T}, X::Array{$T})
-                fptr = get_fptr($(string("vv", f, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{$T}, Ptr{$T}, Ptr{$T}, Ref{Cint}), out1, out2, X, length(X))
+                ccall(($(string("vv",f,suff)),libacc),Cvoid,
+                      (Ptr{$T},Ptr{$T},Ptr{$T},Ref{Cint}),out1,out2,X,length(X))
                 out1, out2
             end
         end
@@ -106,9 +102,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
                 ($f!)(out, X)
             end
             function ($f!)(out::Array{Complex{$T}}, X::Array{$T})
-                fptr = get_fptr($(string("vv", fa, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{Complex{$T}}, Ptr{$T}, Ref{Cint}), out, X, length(X))
+                ccall(($(string("vv",fa,suff)),libacc),Cvoid,
+                      (Ptr{Complex{$T}},Ptr{$T},Ref{Cint}),out,X,length(X))
                 out
             end
         end
@@ -140,10 +135,9 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         @eval begin
             function ($f)(X::Vector{$T})
                 val = Ref{$T}(0.0)
-                fptr = get_fptr($(string("vDSP_", fa, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{$T}, Int64, Ref{$T}, UInt64),
-                    X, 1, val, length(X))
+                ccall(($(string("vDSP_", fa, suff), libacc)),  Cvoid,
+                      (Ptr{$T}, Int64,  Ref{$T}, UInt64),
+                      X, 1, val, length(X))
                 return val[]
             end
         end
@@ -154,11 +148,10 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             function ($f)(X::Vector{$T})
                 index = Ref{Int}(0)
                 val = Ref{$T}(0.0)
-                fptr = get_fptr($(string("vDSP_", fa, suff)))
-                ccall(fptr, Cvoid,
-                    (Ptr{$T}, Int64, Ref{$T}, Ref{Int}, UInt64),
-                    X, 1, val, index, length(X))
-                return (val[], index[] + 1)
+                ccall(($(string("vDSP_", fa, suff), libacc)),  Cvoid,
+                      (Ptr{$T}, Int64,  Ref{$T}, Ref{Int}, UInt64),
+                      X, 1, val, index, length(X))
+                return (val[], index[]+1)
             end
         end
     end
@@ -179,8 +172,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
             """ ->
             function ($f!)(result::Vector{$T}, X::Vector{$T}, Y::Vector{$T})
-                fptr = get_fptr($(string("vDSP_", f, suff)))
-                ccall(fptr,  Cvoid,
+                ccall(($(string("vDSP_", f, suff), libacc)),  Cvoid,
                       (Ptr{$T}, Int64, Ptr{$T},  Int64, Ptr{$T}, Int64,  UInt64),
                       Y, 1, X, 1, result, 1, length(result))
                 return result


### PR DESCRIPTION
Reverts the part of the commits made in https://github.com/JuliaMath/AppleAccelerate.jl/commit/e843a3aca63b0b76e03e0fcd66322f8242e171ad where the first argument to `ccall` is changed to be a function pointer. Now it reverts back to the tuple form `(function_name, library)`

Should fix #51 

---
Due to changes in how macos ships system dylibs, the original check using `isfile`would result in errors, and e843a3a was first made to change the existence check of the accelerate library using `dlopen`. In that commit, since I though it would be good to pass handles to the `ccall` since we already have the handles from the `dlopen` check, the files `src/Array.jl` and `src/DSP.jl` is also changed. Now I see this might not be necessary and can actually be fragile, so the changes to `ccall` is reverted in this PR but we keep the change to check whether the dylib exists.